### PR TITLE
test for neon support and add the compile option if available

### DIFF
--- a/lib/lazyusf/CMakeLists.txt
+++ b/lib/lazyusf/CMakeLists.txt
@@ -30,6 +30,13 @@ set(SOURCES audio.c
 set(CMAKE_POSITION_INDEPENDENT_CODE 1)
 add_library(lazyusf STATIC ${SOURCES})
 
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-mfpu=neon HAS_NEON)
+
+if(HAS_NEON)
+  target_compile_options(lazyusf PRIVATE -mfpu=neon)
+endif()
+
 include(CheckCXXSymbolExists)
 set(CMAKE_REQUIRED_FLAGS -msse2)
 check_cxx_symbol_exists(__SSE2__ "" HAS_SSE2)


### PR DESCRIPTION
Should fix the build for arm builds

Without this change:
```
/usr/lib/gcc-cross/arm-linux-gnueabihf/7/include/arm_neon.h:10933:1: error: inlining failed in call to always_inline ‘vst1q_s8’: target specific option mismatch
 vst1q_s8 (int8_t * __a, int8x16_t __b)
 ^~~~~~~~
```