### PR TITLE
fix gcc-14 errors and warnings

### DIFF
--- a/lib/lazyusf/audiolib.c
+++ b/lib/lazyusf/audiolib.c
@@ -53,9 +53,9 @@ int alUnLink(usf_state_t * state, int paddr) {
 //	_asm int 3
 
 	if (element->next)
-        elementNext->prev = element->prev;
-    if (element->prev)
-        elementPrev->next = element->next;
+        	elementNext->prev = element->prev;
+	if (element->prev)
+        	elementPrev->next = element->next;
 	return 1;
 }
 

--- a/lib/lazyusf/cpu_hle.c
+++ b/lib/lazyusf/cpu_hle.c
@@ -55,7 +55,7 @@ _HLE_Entry entrys[] = {
 
 //char foundlist[2048];
 
-int sort_entrys(void * a, void * b)
+int sort_entrys(const void * a, const void * b)
 {
 	_HLE_Entry * _a = (_HLE_Entry *)a;
 	_HLE_Entry * _b = (_HLE_Entry *)b;

--- a/lib/lazyusf/main.c
+++ b/lib/lazyusf/main.c
@@ -20,18 +20,18 @@ void StopEmulation(usf_state_t * state)
 
 void DisplayError (usf_state_t * state, char * Message, ...) {
 	va_list ap;
-    
-    size_t len = strlen( state->error_message );
-    
-    if ( len )
-        state->error_message[ len++ ] = '\n';
+
+	size_t len = strlen( state->error_message );
+
+	if ( len )
+		state->error_message[ len++ ] = '\n';
 
 	va_start( ap, Message );
 	vsprintf( state->error_message + len, Message, ap );
 	va_end( ap );
-    
-    state->last_error = state->error_message;
-    StopEmulation( state );
+
+	state->last_error = state->error_message;
+	StopEmulation( state );
 
 	//printf("Error: %s\n", Msg);
 }

--- a/lib/lazyusf/memory.c
+++ b/lib/lazyusf/memory.c
@@ -445,8 +445,8 @@ uint32_t r4300i_SB_VAddr ( usf_state_t * state, uint32_t VAddr, uint8_t Value ) 
 	address = state->TLB_Map[VAddr >> 12];
 
 	if (address == 0) { return 0; }
-    if (address + (VAddr ^ 3) - (uintptr_t)state->N64MEM < state->RdramSize)
-        *(uint8_t *)(address + (VAddr ^ 3)) = Value;
+	if (address + (VAddr ^ 3) - (uintptr_t)state->N64MEM < state->RdramSize)
+        	*(uint8_t *)(address + (VAddr ^ 3)) = Value;
 
 	return 1;
 }
@@ -489,8 +489,8 @@ uint32_t r4300i_SH_VAddr ( usf_state_t * state, uint32_t VAddr, uint16_t Value )
 	address = state->TLB_Map[VAddr >> 12];
 
 	if (address == 0) { return 0; }
-    if (address + 1 + (VAddr ^ 2) - (uintptr_t)state->N64MEM < state->RdramSize)
-        *(uint16_t *)(address + (VAddr ^ 2)) = Value;
+	if (address + 1 + (VAddr ^ 2) - (uintptr_t)state->N64MEM < state->RdramSize)
+        	*(uint16_t *)(address + (VAddr ^ 2)) = Value;
 	return 1;
 }
 

--- a/src/USFCodec.cpp
+++ b/src/USFCodec.cpp
@@ -298,7 +298,7 @@ bool CUSFCodec::CheckEndReached(uint8_t* buffer, int size)
 
   if (buffer && buffer[0] == 0)
   {
-    for (unsigned int i = 0; i < size; i++)
+    for (int i = 0; i < size; i++)
     {
       if (buffer[i] != 0)
       {


### PR DESCRIPTION

fix gcc warnings
```
warning: this 'if' clause does not guard... [-Wmisleading-indentation]
```

```
../src/USFCodec.cpp: In member function 'bool CUSFCodec::CheckEndReached(uint8_t*, int)':
../src/USFCodec.cpp:301:32: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  301 |     for (unsigned int i = 0; i < size; i++)
      |                              ~~^~~~~~
```

fix gcc-14 error
```
../lib/lazyusf/cpu_hle.c: In function 'CPUHLE_Scan':
../lib/lazyusf/cpu_hle.c:129:54: error: passing argument 4 of 'qsort' from incompatible pointer type [-Wincompatible-pointer-types]
  129 |         qsort(entries, numEntries, sizeof(*entries), sort_entrys);
      |                                                      ^~~~~~~~~~~
      |                                                      |
      |                                                      int (*)(void *, void *)
In file included from ../lib/lazyusf/usf.h:9,
                 from ../lib/lazyusf/cpu_hle.c:3:
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/stdlib.h:971:34: note: expected '__compar_fn_t' {aka 'int (*)(const void *, const void *)'} but argument is of type 'int (*)(void *, void *)'
  971 |                    __compar_fn_t __compar) __nonnull ((1, 4));
      |                    ~~~~~~~~~~~~~~^~~~~~~~
```